### PR TITLE
Fix gulp copy task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var header = require('gulp-header');
 var cleanCSS = require('gulp-clean-css');
 var rename = require("gulp-rename");
 var uglify = require('gulp-uglify');
+var merge = require('merge-stream');
 var pkg = require('./package.json');
 
 // Set the banner content
@@ -52,13 +53,21 @@ gulp.task('minify-js', function() {
 
 // Copy vendor libraries from /node_modules into /vendor
 gulp.task('copy', function() {
-    gulp.src(['node_modules/bootstrap/dist/**/*', '!**/npm.js', '!**/bootstrap-theme.*', '!**/*.map'])
-        .pipe(gulp.dest('vendor/bootstrap'))
+    var bootstrap = gulp.src([
+            'node_modules/bootstrap/dist/**/*',
+            '!**/npm.js',
+            '!**/bootstrap-theme.*',
+            '!**/*.map'
+        ])
+        .pipe(gulp.dest('vendor/bootstrap'));
 
-    gulp.src(['node_modules/jquery/dist/jquery.js', 'node_modules/jquery/dist/jquery.min.js'])
-        .pipe(gulp.dest('vendor/jquery'))
+    var jquery = gulp.src([
+            'node_modules/jquery/dist/jquery.js',
+            'node_modules/jquery/dist/jquery.min.js'
+        ])
+        .pipe(gulp.dest('vendor/jquery'));
 
-    gulp.src([
+    var fontAwesome = gulp.src([
             'node_modules/font-awesome/**',
             '!node_modules/font-awesome/**/*.map',
             '!node_modules/font-awesome/.npmignore',
@@ -66,8 +75,10 @@ gulp.task('copy', function() {
             '!node_modules/font-awesome/*.md',
             '!node_modules/font-awesome/*.json'
         ])
-        .pipe(gulp.dest('vendor/font-awesome'))
-})
+        .pipe(gulp.dest('vendor/font-awesome'));
+
+    return merge(bootstrap, jquery, fontAwesome);
+});
 
 // Run everything
 gulp.task('default', ['less', 'minify-css', 'minify-js', 'copy']);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "gulp-less": "^3.1.0",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.4",
-    "jquery": "^1.11.3"
+    "jquery": "^1.11.3",
+    "merge-stream": "^1.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- ensure gulpfile returns stream when copying vendor files
- add merge-stream package for merging gulp streams

## Testing
- `npm test` *(fails: Missing script)*
- `npx gulp --tasks-simple` *(fails: Assertion failed in ContextifyScript)*

------
https://chatgpt.com/codex/tasks/task_e_684690bfa390833289f502dd83a8b65a